### PR TITLE
fixed fragment logic and tile click logic

### DIFF
--- a/app/src/main/java/org/pursuit/pursuitjeopardy/Animations.java
+++ b/app/src/main/java/org/pursuit/pursuitjeopardy/Animations.java
@@ -34,6 +34,9 @@ public class Animations {
             public void onAnimationStart(Animation animation) {
                 cardview.setElevation(1000000000);
                 linearLayout.setElevation(999999998);
+                cardview.setEnabled(false);
+
+
             }
 
             @Override
@@ -59,11 +62,10 @@ public class Animations {
 
                     @Override
                     public void onAnimationEnd(Animator animation) {
-                        cardview.setOnClickListener(null);
-                        cardview.clearAnimation();
+                        cardview.setEnabled(true);
                         cardview.setBackgroundColor(cardview.getResources().getColor(
-                                R.color.cardview_was_already_previously_selected_already_color));
-                        cardview.setAlpha(.4f);
+                                R.color.cardview_color));
+                        cardview.setAlpha(1.0f);
                     }
 
                     @Override

--- a/app/src/main/java/org/pursuit/pursuitjeopardy/controller/OnFragmentInteractionListener.java
+++ b/app/src/main/java/org/pursuit/pursuitjeopardy/controller/OnFragmentInteractionListener.java
@@ -1,8 +1,11 @@
 package org.pursuit.pursuitjeopardy.controller;
 
-public interface OnFragmentInteractionListener {
+import android.view.View;
 
+public interface OnFragmentInteractionListener {
     void displayQuestion(String key);
 
     void displayResult(boolean isCorrect);
+
+    void checkTileIsAnswered(boolean isAnswered, String key);
 }

--- a/app/src/main/java/org/pursuit/pursuitjeopardy/view/GameBoardActivity.java
+++ b/app/src/main/java/org/pursuit/pursuitjeopardy/view/GameBoardActivity.java
@@ -3,9 +3,13 @@ package org.pursuit.pursuitjeopardy.view;
 import android.arch.lifecycle.ViewModelProviders;
 import android.graphics.drawable.Drawable;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.support.v7.widget.CardView;
+import android.util.Log;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
@@ -22,13 +26,17 @@ public final class GameBoardActivity extends AppCompatActivity implements OnFrag
     private QuestionViewModel viewModel;
     private List<LinearLayout> layoutList;
     private Drawable[] drawables;
+    static final String QUESTION_FRAGMENT_KEY = "question";
+    static final String RESULT_FRAGMENT_KEY = "result";
+    private ViewGroup viewGroup;
+
 
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_game_board);
-        final ViewGroup viewGroup = (ViewGroup) ((ViewGroup) this
+        viewGroup = (ViewGroup) ((ViewGroup) this
                 .findViewById(android.R.id.content)).getChildAt(0);
         viewGroup.setClipChildren(false);
         findAndLoadLayout();
@@ -71,24 +79,56 @@ public final class GameBoardActivity extends AppCompatActivity implements OnFrag
 
     @Override
     public void displayQuestion(String key) {
-        inflateFragment(QuestionFragment.newInstance(key), true);
+        Fragment fragment = QuestionFragment.newInstance(key);
+        inflateFragment(fragment,QUESTION_FRAGMENT_KEY,true);
     }
 
     @Override
     public void displayResult(boolean isCorrect) {
-        inflateFragment(ResultFragment.newInstance(isCorrect));
+        Fragment fragment = ResultFragment.newInstance(isCorrect);
+        FragmentManager fragmentManager = getSupportFragmentManager();
+
+        Fragment destroyFragment = fragmentManager.findFragmentByTag(QUESTION_FRAGMENT_KEY);
+
+        if(destroyFragment != null){
+            fragmentManager.beginTransaction().remove(destroyFragment).commit();
+        }
+        inflateFragment(fragment,RESULT_FRAGMENT_KEY,true);
+
     }
 
-    private void inflateFragment(Fragment fragment) {
-        inflateFragment(fragment, false);
+    @Override
+    public void checkTileIsAnswered(boolean isAnswered, String checkKey) {
+        CardView cardview = viewGroup.findViewWithTag(checkKey);
+        Log.d("cardview",cardview.getTag().toString());
+
+        if(!isAnswered){
+            cardview.setEnabled(true);
+            cardview.setBackgroundColor(cardview.getResources().getColor(
+                    R.color.cardview_color));
+            cardview.setAlpha(1.0f);
+        }else{
+            cardview.setEnabled(false);
+            cardview.setBackgroundColor(cardview.getResources().getColor(
+                    R.color.cardview_was_already_previously_selected_already_color));
+            cardview.setAlpha(.4f);
+        }
     }
 
-    private void inflateFragment(Fragment fragment, boolean addToBack) {
+    private void inflateFragment(Fragment fragment,String fragmentKey) {
+        inflateFragment(fragment, fragmentKey, false);
+    }
+
+    private void inflateFragment(Fragment fragment, String fragmentKey, boolean addToBack) {
         FragmentTransaction fragmentTransaction = getSupportFragmentManager()
                 .beginTransaction()
-                .replace(R.id.fragment_container, fragment);
+                .replace(R.id.fragment_container, fragment, fragmentKey);
         if (addToBack) fragmentTransaction.addToBackStack(null);
         fragmentTransaction.commit();
     }
+
+
+
+
 
 }

--- a/app/src/main/java/org/pursuit/pursuitjeopardy/view/QuestionFragment.java
+++ b/app/src/main/java/org/pursuit/pursuitjeopardy/view/QuestionFragment.java
@@ -29,6 +29,7 @@ public final class QuestionFragment extends Fragment implements View.OnClickList
     private Button submitButton;
     private String viewmodelKey;
 
+
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
@@ -77,6 +78,7 @@ public final class QuestionFragment extends Fragment implements View.OnClickList
             radioButtonView.setText(ab[i]);
             answerRadioGroup.addView(radioButtonView, i);
         }
+        onFragmentInteractionListener.checkTileIsAnswered(false,viewmodelKey);
         view.animate().alpha(1.0f).setStartDelay(1000).setDuration(1200);
     }
 
@@ -87,6 +89,9 @@ public final class QuestionFragment extends Fragment implements View.OnClickList
                 .getCorrect(viewmodelKey)
                 .equals(radioButton.getText().toString());
 
+
+        onFragmentInteractionListener.checkTileIsAnswered(true,viewmodelKey);
         onFragmentInteractionListener.displayResult(isCorrect);
     }
+
 }


### PR DESCRIPTION
fragments are inflated with tags that can be used to search and *forcefully* destroy them.
*could not figure out why our code didnt work*

implemented logic to check if a question was answered by adding a method to fragment interface.

there is now a bug where if user doesn't answer a question, and goes back, upon selecting another question, the answer choices concatenate.
 also correct answer is always last.